### PR TITLE
PSO User folder path

### DIFF
--- a/ArksLayer.Tweaker.Abstractions/TweakerSettingsExtensions.cs
+++ b/ArksLayer.Tweaker.Abstractions/TweakerSettingsExtensions.cs
@@ -41,8 +41,8 @@ namespace ArksLayer.Tweaker.Abstractions
         /// </summary>
         public static string GetUserFolderPath(this ITweakerSettings settings)
         {
-            var documents = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            return Path.Combine(documents, @"Documents\SEGA\PHANTASYSTARONLINE2");
+            var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            return Path.Combine(documents, @"SEGA\PHANTASYSTARONLINE2");
         }
 #pragma warning restore RECS0154 // Parameter is never used
 


### PR DESCRIPTION
Get "MyDocuments" folder path if moved from default user folder (or non EN language OS) and avoid duplication of "Documents" in user folder.